### PR TITLE
Proposed updates to client-specs PR

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -1,14 +1,6 @@
 class Api::V0::BaseController < ApplicationController
 
-  # clear the cache when testing so that it's up-to-date
-  # with models that were just created in specs
-  before_action(:clear_apps_cache!) if Rails.env.test?
-
   protected
-
-  def clear_apps_cache!
-    apps.refresh!
-  end
 
   def bind(data, bindings_class)
     begin

--- a/app/models/cached_apps.rb
+++ b/app/models/cached_apps.rb
@@ -16,9 +16,12 @@ class CachedApps
     find_by_api_token(api_token).present?
   end
 
+  def does_api_id_exist?(api_id)
+    find_by_api_id(api_id).present?
+  end
+
   def does_api_id_origin_combo_exist?(api_id, origin)
-    refresh_if_needed!
-    app = @apps.by_api_id[api_id]
+    app = find_by_api_id(api_id)
     app.present? && app.url_is_whitelisted?(origin)
   end
 

--- a/spec/clients/v0/ruby_spec.rb
+++ b/spec/clients/v0/ruby_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 
-describe 'Ruby client', type: :api do
+describe 'Ruby client', type: :api_client do
 
   let(:api_id) { "a_valid_api_id" }
   let(:api_token) { "a_valid_api_token" }

--- a/spec/clients/v0/ruby_spec.rb
+++ b/spec/clients/v0/ruby_spec.rb
@@ -1,15 +1,16 @@
-require_relative '../../rails_helper'
+require 'rails_helper'
 
 
 describe 'Ruby client', type: :api do
 
-  let!(:app) do
-    app = App.create.tap do |app|
-      app.update(name: "whatever", whitelisted_domains: "openstax.org")
-    end
-  end
+  let(:api_id) { "a_valid_api_id" }
+  let(:api_token) { "a_valid_api_token" }
 
   before(:each) {
+    # Always create the app with the same ID and token so that the cached apps in the Capybara
+    # server match up even tho redis is cleared after every example
+    app = App.create(api_id: api_id, api_token: api_token, whitelisted_domains: ["openstax.org"])
+
     A15kInteractions.configure do |c|
       # c.debugging = true
       c.scheme = 'http'
@@ -21,7 +22,6 @@ describe 'Ruby client', type: :api do
   describe 'Interactions' do
     describe 'Apps' do
       let(:api_client) { A15kInteractions::AppsApi.new }
-
     end
 
     describe 'Flagging' do

--- a/spec/controllers/api/v0/base_controller_spec.rb
+++ b/spec/controllers/api/v0/base_controller_spec.rb
@@ -62,6 +62,24 @@ RSpec.describe Api::V0::BaseController, type: :controller, api: :v0 do
       expect(response).to have_http_status(:forbidden)
     end
 
+    it "gives unauthorized for missing token and good ID" do
+      set_api_id(an_app.api_id)
+      get :test_authenticate_api_token
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "gives unauthorized for sneaky attempt to set both token and ID" do
+      set_api_token("ID #{an_app.api_id}")
+      get :test_authenticate_api_token
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "gives unauthorize for sneaky attempt #2 to set both token and ID" do
+      set_authorization_header("Token fake , ID #{an_app.api_id}")
+      get :test_authenticate_api_token
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it "gives success for good token" do
       set_api_token(an_app.api_token)
       get :test_authenticate_api_token
@@ -111,6 +129,13 @@ RSpec.describe Api::V0::BaseController, type: :controller, api: :v0 do
       # do not set origin
       get :test_authenticate_api_id_and_domain
       expect(response).to have_http_status(:ok)
+    end
+
+    it "gives forbidden for bad id and missing domain" do
+      set_api_id("blah")
+      # do not set origin
+      get :test_authenticate_api_id_and_domain
+      expect(response).to have_http_status(:forbidden)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,10 +57,9 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation, only: ["#{redis_namespace}:*"])
   end
 
-  config.before(:each, type: :api) do
-    Capybara.current_driver = :api
-    visit :api # force api to have the server booted and available
-    DatabaseCleaner.strategy = :truncation
+  config.before(:each, type: :api_client) do
+    Capybara.current_driver = :api_client
+    visit 'api' # visit some existing route to force the server to be booted and available
   end
 
   config.before(:each) do

--- a/spec/shared_examples/api/v0/admin_token_checks.rb
+++ b/spec/shared_examples/api/v0/admin_token_checks.rb
@@ -3,21 +3,35 @@ RSpec.shared_examples "v0 admin token checks" do |route_prefix:, actions:|
   context "invalid admin token" do
     before { set_bad_admin_api_token }
 
-    test_request_status(self, :post, "#{route_prefix}", :forbidden) if create?(actions)
-    test_request_status(self, :get, "#{route_prefix}/42", :forbidden) if show?(actions)
-    test_request_status(self, :get, "#{route_prefix}", :forbidden) if index?(actions)
-    test_request_status(self, :put, "#{route_prefix}/42", :forbidden) if update?(actions)
-    test_request_status(self, :delete, "#{route_prefix}/42", :forbidden) if destroy?(actions)
+    test_crud_request_status(self, route_prefix, :forbidden, actions)
+
+    context "but good API ID" do
+      before do
+        app = App.create.tap do |app|
+          app.update(name: "whatever", whitelisted_domains: "openstax.org")
+        end
+        set_api_id(app.api_id)
+      end
+
+      # Setting API ID when not asked will give unauthorized
+      test_crud_request_status(self, route_prefix, :unauthorized, actions)
+    end
   end
 
   context "missing admin token" do
     before { clear_api_token }
 
-    test_request_status(self, :post, "#{route_prefix}", :unauthorized) if create?(actions)
-    test_request_status(self, :get, "#{route_prefix}/42", :unauthorized)if show?(actions)
-    test_request_status(self, :get, "#{route_prefix}", :unauthorized) if index?(actions)
-    test_request_status(self, :put, "#{route_prefix}/42", :unauthorized) if update?(actions)
-    test_request_status(self, :delete, "#{route_prefix}/42", :unauthorized) if destroy?(actions)
-  end
+    test_crud_request_status(self, route_prefix, :unauthorized, actions)
 
+    context "but good API ID" do
+      before do
+        app = App.create.tap do |app|
+          app.update(name: "whatever", whitelisted_domains: "openstax.org")
+        end
+        set_api_id(app.api_id)
+      end
+
+      test_crud_request_status(self, route_prefix, :unauthorized, actions)
+    end
+  end
 end

--- a/spec/shared_examples/api/v0/api_id_checks.rb
+++ b/spec/shared_examples/api/v0/api_id_checks.rb
@@ -10,33 +10,21 @@ RSpec.shared_examples "v0 API ID checks" do |route_prefix:, actions:|
     before { clear_api_id }
     before { set_origin("https://blah.openstax.org") }
 
-    test_request_status(self, :post, "#{route_prefix}", :unauthorized) if create?(actions)
-    test_request_status(self, :get, "#{route_prefix}/42", :unauthorized)if show?(actions)
-    test_request_status(self, :get, "#{route_prefix}", :unauthorized) if index?(actions)
-    test_request_status(self, :put, "#{route_prefix}/42", :unauthorized) if update?(actions)
-    test_request_status(self, :delete, "#{route_prefix}/42", :unauthorized) if destroy?(actions)
+    test_crud_request_status(self, route_prefix, :unauthorized, actions)
   end
 
   context "valid API ID and invalid origin" do
     before { set_api_id(an_app_for_api_id_checks.api_id) }
     before { set_origin("https://notright.io") }
 
-    test_request_status(self, :post, "#{route_prefix}", :forbidden) if create?(actions)
-    test_request_status(self, :get, "#{route_prefix}/42", :forbidden) if show?(actions)
-    test_request_status(self, :get, "#{route_prefix}", :forbidden) if index?(actions)
-    test_request_status(self, :put, "#{route_prefix}/42", :forbidden) if update?(actions)
-    test_request_status(self, :delete, "#{route_prefix}/42", :forbidden) if destroy?(actions)
+    test_crud_request_status(self, route_prefix, :forbidden, actions)
   end
 
   context "invalid API ID and valid origin" do
     before { set_api_id("notreal") }
     before { set_origin("https://blah.openstax.org") }
 
-    test_request_status(self, :post, "#{route_prefix}", :forbidden) if create?(actions)
-    test_request_status(self, :get, "#{route_prefix}/42", :forbidden) if show?(actions)
-    test_request_status(self, :get, "#{route_prefix}", :forbidden) if index?(actions)
-    test_request_status(self, :put, "#{route_prefix}/42", :forbidden) if update?(actions)
-    test_request_status(self, :delete, "#{route_prefix}/42", :forbidden) if destroy?(actions)
+    test_crud_request_status(self, route_prefix, :forbidden, actions)
   end
 
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -9,7 +9,7 @@ class ApiDriver < Capybara::Driver::Base
   def visit(path); end
 end
 
-Capybara.register_driver :api do |app|
+Capybara.register_driver :api_client do |app|
   ApiDriver.new
 end
 
@@ -27,6 +27,6 @@ module ApiHelpers
 end
 
 RSpec.configure do |config|
-  config.include Capybara::DSL, type: :api
-  config.include ApiHelpers, type: :api
+  config.include Capybara::DSL, type: :api_client
+  config.include ApiHelpers, type: :api_client
 end

--- a/spec/support/api_v0_helpers.rb
+++ b/spec/support/api_v0_helpers.rb
@@ -139,6 +139,14 @@ module ApiV0Helpers
         expect(response).to have_http_status(status)
       end
     end
+
+    def test_crud_request_status(spec, route_prefix, status, actions)
+      test_request_status(spec, :post, "#{route_prefix}", status) if create?(actions)
+      test_request_status(spec, :get, "#{route_prefix}/42", status) if show?(actions)
+      test_request_status(spec, :get, "#{route_prefix}", status) if index?(actions)
+      test_request_status(spec, :put, "#{route_prefix}/42", status) if update?(actions)
+      test_request_status(spec, :delete, "#{route_prefix}/42", status) if destroy?(actions)
+    end
   end
 
 end


### PR DESCRIPTION
* Took out the `current_app` code - while it did work, it made me nervous that a future dev slip could allow an API ID to be used in place of an API Token.  Also think it was probably around to use `current_app` elsewhere (e.g. to get a whitelisted domain).
* Added some other security specs (stuff I should have had before)
* Added an extra check to make sure API ID isn't used in place of API Token (belt and suspenders)
* Replaced the `clear_apps_cache!` `before_action` with just setting up the same `App` on every test.  If we left the `before_action` in we wouldn't be able to write a request spec that tested the caching of apps across multiple API calls.
* Changed `type: :api` to `type: :api_client` in the client spec code just for clarity (since we have the symbol `:api` in some other places).